### PR TITLE
CICD 설정 및 Android apk 배포 기준 브랜치를 main으로 변경

### DIFF
--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -34,11 +34,6 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      - name: Wait for build to complete
-        run: eas build:wait --platform android --non-interactive
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
       - name: Get latest build URL
         id: get_url
         run: |

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -16,8 +16,8 @@ jobs:
           submodules: true
           token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
 
-      - name: Copy development/.env to .env
-        run: cp env/development/.env .env
+      - name: Copy /FE/development/.env to .env
+        run: cp env/FE/development/.env .env
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -1,0 +1,49 @@
+name: Build APK and Upload to Discord
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Authenticate with EAS
+        run: eas whoami
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start EAS build (APK)
+        run: eas build --platform android --non-interactive --profile development
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      - name: Get latest build URL
+        id: get_url
+        run: |
+          BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
+          echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      - name: Send to Discord
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+          -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -62,8 +62,9 @@ jobs:
 
       - name: Send to Discord
         run: |
+          TIMESTAMP=$(TZ='Asia/Seoul' date +'%Y-%m-%d %H:%M:%S KST')
           curl -X POST -H "Content-Type: application/json" \
           -d "{
-            \"content\": \"🌿 **Branch**\n\`${{ github.ref_name }}\`\n\n🔗 **Download**\n[Click here to download the APK](${{ steps.build_info.outputs.url }})\n\n📱 **App Version**\n\`${{ steps.build_info.outputs.version }}\`\n\n📝 **Last Commit**\n[\`${{ steps.build_info.outputs.commit_msg }}\`](https://github.com/diningBuddy/fe/commit/${{ steps.build_info.outputs.commit_hash }})\n\n🕒 **Build Timestamp**\n$(date -u +'%Y-%m-%dT%H:%M:%SZ')\"
+            \"content\": \"🌿 **Branch**\n\`${{ github.ref_name }}\`\n\n🔗 **Download**\n[Click here to download the APK](${{ steps.build_info.outputs.url }})\n\n📱 **App Version**\n\`${{ steps.build_info.outputs.version }}\`\n\n📝 **Last Commit**\n[\`${{ steps.build_info.outputs.commit_msg }}\`](https://github.com/diningBuddy/fe/commit/${{ steps.build_info.outputs.commit_hash }})\n\n🕒 **Build Timestamp**\n${TIMESTAMP}\"
           }" \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -10,8 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
+      - name: Checkout repo (with submodules)
         uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
+
+      - name: Copy development/.env to .env
+        run: cp env/development/.env .env
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -26,39 +32,24 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      - name: Get latest build URL
-        id: get_url
-        run: |
-          BUILD_JSON=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json)
-          echo "JSON Output: $BUILD_JSON"
-          if [ -n "$BUILD_JSON" ] && [ "$BUILD_JSON" != "[]" ]; then
-            BUILD_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.buildUrl')
-            echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
-          else
-            echo "No finished builds found"
-            exit 1
-          fi
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start EAS build (APK)
+        run: eas build --platform android --non-interactive --profile development
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      # - name: Install dependencies
-      #   run: npm ci
+      - name: Get latest build URL
+        id: get_url
+        run: |
+          BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
+          echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      # - name: Start EAS build (APK)
-      #   run: eas build --platform android --non-interactive --profile development
-      #   env:
-      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
-      # - name: Get latest build URL
-      #   id: get_url
-      #   run: |
-      #     BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
-      #     echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
-      #   env:
-      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
-      # - name: Send to Discord
-      #   run: |
-      #     curl -X POST -H "Content-Type: application/json" \
-      #     -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
-      #     ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Send to Discord
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+          -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -21,29 +21,44 @@ jobs:
       - name: Install EAS CLI
         run: npm install -g eas-cli
 
-      - name: Authenticate with EAS
-        run: eas whoami
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Start EAS build (APK)
-        run: eas build --platform android --non-interactive --profile development
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
       - name: Get latest build URL
         id: get_url
         run: |
-          BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
-          echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+          BUILD_JSON=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json)
+          echo "JSON Output: $BUILD_JSON"
+          if [ -n "$BUILD_JSON" ] && [ "$BUILD_JSON" != "[]" ]; then
+            BUILD_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.buildUrl')
+            echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+          else
+            echo "No finished builds found"
+            exit 1
+          fi
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      - name: Send to Discord
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-          -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK_URL }}
+      # - name: Authenticate with EAS
+      #   run: eas whoami
+      #   env:
+      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      # - name: Install dependencies
+      #   run: npm ci
+
+      # - name: Start EAS build (APK)
+      #   run: eas build --platform android --non-interactive --profile development
+      #   env:
+      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      # - name: Get latest build URL
+      #   id: get_url
+      #   run: |
+      #     BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
+      #     echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+      #   env:
+      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
+      # - name: Send to Discord
+      #   run: |
+      #     curl -X POST -H "Content-Type: application/json" \
+      #     -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
+      #     ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -40,16 +40,30 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
-      - name: Get latest build URL
-        id: get_url
+      - name: Get latest build info
+        id: build_info
         run: |
-          BUILD_URL=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json | jq -r '.[0].artifacts.buildUrl')
-          echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
+          echo "Getting latest build info..."
+
+          BUILD_JSON=$(eas build:list --limit 1 --platform android --status finished --non-interactive --json)
+
+          # Extract values
+          BUILD_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.buildUrl')
+          APP_VERSION=$(echo "$BUILD_JSON" | jq -r '.[0].appVersion')
+          COMMIT_HASH=$(echo "$BUILD_JSON" | jq -r '.[0].gitCommitHash')
+          COMMIT_MSG=$(echo "$BUILD_JSON" | jq -r '.[0].gitCommitMessage')
+
+          echo "url=$BUILD_URL" >> $GITHUB_OUTPUT
+          echo "version=$APP_VERSION" >> $GITHUB_OUTPUT
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "commit_msg=$COMMIT_MSG" >> $GITHUB_OUTPUT
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
       - name: Send to Discord
         run: |
           curl -X POST -H "Content-Type: application/json" \
-          -d "{\"content\": \"APK 빌드 완료!\n👉 ${BUILD_URL}\"}" \
+          -d "{
+            \"content\": \"🌿 **Branch**\n\`${{ github.ref_name }}\`\n\n🔗 **Download**\n[Click here to download the APK](${{ steps.build_info.outputs.url }})\n\n📱 **App Version**\n\`${{ steps.build_info.outputs.version }}\`\n\n📝 **Last Commit**\n[\`${{ steps.build_info.outputs.commit_msg }}\`](https://github.com/diningBuddy/fe/commit/${{ steps.build_info.outputs.commit_hash }})\n\n🕒 **Build Timestamp**\n$(date -u +'%Y-%m-%dT%H:%M:%SZ')\"
+          }" \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -34,6 +34,11 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
+      - name: Wait for build to complete
+        run: eas build:wait --platform android --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
       - name: Get latest build URL
         id: get_url
         run: |

--- a/.github/workflows/build-apk-dev.yml
+++ b/.github/workflows/build-apk-dev.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Install EAS CLI
         run: npm install -g eas-cli
 
+      - name: Authenticate with EAS
+        run: eas whoami
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
+
       - name: Get latest build URL
         id: get_url
         run: |
@@ -35,11 +40,6 @@ jobs:
           fi
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
-
-      # - name: Authenticate with EAS
-      #   run: eas whoami
-      #   env:
-      #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN_DEV }}
 
       # - name: Install dependencies
       #   run: npm ci

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "env"]
+	path = env
+	url = https://github.com/diningBuddy/env.git

--- a/app.config.ts
+++ b/app.config.ts
@@ -39,8 +39,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       env: {
         KAKAO_NATIVE_APP_KEY: process.env.KAKAO_NATIVE_APP_KEY,
         ENVIRONMENT: process.env.ENVIRONMENT,
-        DEV_API_HOST: process.env.DEV_API_HOST,
-        PROD_API_HOST: process.env.PROD_API_HOST,
+        API_HOST: process.env.API_HOST,
       },
     },
     owner: "meokguskku",

--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,7 @@
       "env": {
         "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
         "ENVIRONMENT": "dev",
-        "DEV_API_HOST": "$(DEV_API_HOST)"
+        "API_HOST": "$(API_HOST)"
       }
     },
     "preview": {

--- a/eas.json
+++ b/eas.json
@@ -5,7 +5,12 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
+        "ENVIRONMENT": "dev",
+        "DEV_API_HOST": "$(DEV_API_HOST)"
+      }
     },
     "preview": {
       "distribution": "internal"

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -6,8 +6,7 @@ type Environment = "local" | "dev" | "prod";
 interface EnvVariables {
   ENVIRONMENT: Environment;
   KAKAO_NATIVE_APP_KEY: string;
-  DEV_API_HOST: string;
-  PROD_API_HOST: string;
+  API_HOST: string;
 }
 
 class EnvironmentError extends Error {
@@ -37,18 +36,8 @@ export const getEnv = (): EnvVariables => {
     throw new EnvironmentError("KAKAO_NATIVE_APP_KEY");
   }
 
-  switch (env.ENVIRONMENT) {
-    case "local":
-    case "dev":
-      if (!env.DEV_API_HOST) {
-        throw new EnvironmentError("DEV_API_HOST");
-      }
-      break;
-    case "prod":
-      if (!env.PROD_API_HOST) {
-        throw new EnvironmentError("PROD_API_HOST");
-      }
-      break;
+  if (!env.API_HOST) {
+    throw new EnvironmentError("API_HOST");
   }
 
   return env;
@@ -85,20 +74,9 @@ export const getKakaoNativeAppKey = (): string => {
  * @throws EnvironmentError 환경에 맞는 API 호스트가 정의되지 않았을 때
  */
 export const getApiHost = (): string => {
-  const { environment } = getEnvironment();
   const env = getEnv();
 
-  switch (environment) {
-    case "local":
-    case "dev":
-      return env.DEV_API_HOST;
-
-    case "prod":
-      return env.PROD_API_HOST;
-
-    default:
-      throw new EnvironmentError();
-  }
+  return env.API_HOST;
 };
 
 /**

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,7 +23,7 @@ class EnvironmentError extends Error {
  * @throws EnvironmentError 환경 변수가 정의되지 않았을 때
  */
 export const getEnv = (): EnvVariables => {
-  const env = Constants.expoConfig?.extra?.env;
+  const env = Constants.expoConfig?.extra?.env as EnvVariables;
 
   if (!env) {
     throw new EnvironmentError();
@@ -37,15 +37,21 @@ export const getEnv = (): EnvVariables => {
     throw new EnvironmentError("KAKAO_NATIVE_APP_KEY");
   }
 
-  if (!env.DEV_API_HOST) {
-    throw new EnvironmentError("DEV_API_HOST");
+  switch (env.ENVIRONMENT) {
+    case "local":
+    case "dev":
+      if (!env.DEV_API_HOST) {
+        throw new EnvironmentError("DEV_API_HOST");
+      }
+      break;
+    case "prod":
+      if (!env.PROD_API_HOST) {
+        throw new EnvironmentError("PROD_API_HOST");
+      }
+      break;
   }
 
-  if (!env.PROD_API_HOST) {
-    throw new EnvironmentError("PROD_API_HOST");
-  }
-
-  return env as EnvVariables;
+  return env;
 };
 
 /**


### PR DESCRIPTION
- Android APK 배포 기준 브랜치 변경
기존: develop 브랜치에 머지될 때 Android apk 자동 빌드 및 배포
변경: main 브랜치에 머지될 때 배포되도록 기준 브랜치 변경

개발 작업은 develop 브랜치에 모아 두고, 주기적으로 main 브랜치에 머지하면서 배포하는 구조로 결정하였습니다!